### PR TITLE
ルート保存後、すぐにデータが反映されるようにした

### DIFF
--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/home/HomeScreen.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/home/HomeScreen.kt
@@ -21,16 +21,26 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import net.harutiro.trainalert2.TrainAlertApplication // Ensure to import your application context
 import net.harutiro.trainalert2.features.notification.api.NotificationApi
 import net.harutiro.trainalert2.features.room.routeDB.entities.RouteEntity
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+
 
 @Composable
 fun HomeScreen(
     toRouteEditor: (Int?) -> Unit,
-    viewModel: HomeViewModel = viewModel()
+    viewModel: HomeViewModel = viewModel() // ここで viewModel を宣言
 ) {
     val context = LocalContext.current
     val routeList by viewModel.routeList.collectAsState(initial = emptyList())
     val (showDeleteDialog, setShowDeleteDialog) = remember { mutableStateOf<Pair<RouteEntity, Boolean>?>(null) }
 
+    // 画面が表示されるときにデータをロードする
+    LaunchedEffect(Unit) {
+        viewModel.loadAllRoutes()
+    }
+
+    // ルートリストの表示
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/home/HomeViewModel.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/home/HomeViewModel.kt
@@ -36,11 +36,12 @@ class HomeViewModel : ViewModel() {
         }
     }
 
-
     // ルートを取得する
-    private fun loadAllRoutes() {
+    fun loadAllRoutes() {
         viewModelScope.launch(Dispatchers.IO) {
             _routeList.value = routeRepository.loadAllRoutes()
         }
     }
+
+
 }

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
@@ -19,12 +19,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import net.harutiro.trainalert2.core.presenter.home.HomeViewModel
 
 @Composable
 fun RouteEditScreen(
     toBackScreen: () -> Unit,
-    viewModel: RouteEditorViewModel = viewModel()
+    homeViewModel: HomeViewModel = viewModel()
 ) {
+    val viewModel: RouteEditorViewModel = viewModel(factory = RouteEditorViewModelFactory(homeViewModel))
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorViewModel.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorViewModel.kt
@@ -9,13 +9,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import net.harutiro.trainalert2.core.presenter.home.HomeViewModel
 import net.harutiro.trainalert2.features.room.routeDB.entities.RouteEntity
 import net.harutiro.trainalert2.features.room.routeDB.repositories.RouteRepository
 
-class RouteEditorViewModel: ViewModel() {
+class RouteEditorViewModel(private val homeViewModel: HomeViewModel) : ViewModel() {
 
     // Repositoryのインスタンスを取得
     private val repository = RouteRepository()
+
 
     var title by mutableStateOf("")
     var startLongitude by mutableStateOf("")
@@ -65,6 +67,10 @@ class RouteEditorViewModel: ViewModel() {
         // Repositoryを介してデータベースに保存
         viewModelScope.launch(Dispatchers.IO) {
             repository.saveRoute(routeEntity)
+            // 保存処理が完了したらUIスレッドでルートを再ロード
+            viewModelScope.launch(Dispatchers.Main) {
+                homeViewModel.loadAllRoutes()
+            }
         }
     }
 

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorViewModelFactory.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorViewModelFactory.kt
@@ -1,0 +1,16 @@
+package net.harutiro.trainalert2.core.presenter.routeEditer
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import net.harutiro.trainalert2.core.presenter.home.HomeViewModel
+
+class RouteEditorViewModelFactory(
+    private val homeViewModel: HomeViewModel
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(RouteEditorViewModel::class.java)) {
+            return RouteEditorViewModel(homeViewModel) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
ルートを新規作成して保存ボタンを押してホーム画面に遷移した際に、即座にリストが更新されるようにした