### PR TITLE
ルート編集画面で、位置情報の設定をする時にマップを使えるようにしました。

### DIFF
--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
@@ -1,0 +1,81 @@
+package net.harutiro.trainalert2.core.presenter.LocationSelect
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapEffect
+import com.google.maps.android.compose.MapsComposeExperimentalApi
+import com.google.maps.android.compose.rememberCameraPositionState
+import net.harutiro.trainalert2.features.map.repository.MapOptions
+
+@OptIn(MapsComposeExperimentalApi::class)
+@Composable
+fun LocationSelectScreen(
+    viewModel:LocationSelectViewModel = viewModel()
+){
+
+    val context = LocalContext.current
+    viewModel.init(context)
+
+    val cameraPositionState = rememberCameraPositionState {
+        val defaultPosition = LatLng(35.681236, 139.767125)
+        val defaultZoom = 14f
+        position = CameraPosition.fromLatLngZoom(defaultPosition, defaultZoom)
+    }
+
+    viewModel.changeLocation(
+        cameraPositionState = cameraPositionState
+    )
+
+
+    Box{
+        GoogleMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState
+        ) {
+            MapEffect { map ->
+                //パーミッションチェック
+                if (ActivityCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.ACCESS_FINE_LOCATION
+                    ) == PackageManager.PERMISSION_GRANTED &&
+                    ActivityCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.ACCESS_COARSE_LOCATION
+                    ) == PackageManager.PERMISSION_GRANTED
+                ) {
+                    map.isMyLocationEnabled = true
+                }
+            }
+        }
+
+        Button(
+            onClick = {
+            },
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 32.dp)
+        ){
+            Text("この座標で保存する")
+        }
+
+    }
+
+
+}

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
@@ -119,8 +119,8 @@ fun LocationSelectScreen(
 
         Button(
             onClick = {
-                selectedLocation = LatLng(0.0,0.0)
                 toBackEditor(selectedLocation)
+                selectedLocation = LatLng(0.0,0.0)
             },
             enabled = selectedLocation != LatLng(0.0,0.0),
             modifier = Modifier

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
@@ -78,7 +78,20 @@ fun LocationSelectScreen(
 
             Marker(
                 state = MarkerState(viewModel.selectLatLon),
-                title = "hogehoge",
+                title =
+                    "緯度: ${
+                        String.format(
+                            Locale.JAPAN,
+                            "%.6f",
+                            viewModel.selectLatLon.latitude
+                        )
+                    }　経度: ${
+                        String.format(
+                            Locale.JAPAN,
+                            "%.6f",
+                            viewModel.selectLatLon.longitude
+                        )
+                    }"
             )
         }
 

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
@@ -1,15 +1,21 @@
 package net.harutiro.trainalert2.core.presenter.LocationSelect
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.pm.PackageManager
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -21,15 +27,18 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapEffect
 import com.google.maps.android.compose.MapsComposeExperimentalApi
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import net.harutiro.trainalert2.features.map.repository.MapOptions
+import java.util.Locale
 
 @OptIn(MapsComposeExperimentalApi::class)
 @Composable
 fun LocationSelectScreen(
-    viewModel:LocationSelectViewModel = viewModel()
+    toBackEditor:(LatLng) -> Unit,
+    viewModel:LocationSelectViewModel = viewModel(),
 ){
-
     val context = LocalContext.current
     viewModel.init(context)
 
@@ -47,7 +56,10 @@ fun LocationSelectScreen(
     Box{
         GoogleMap(
             modifier = Modifier.fillMaxSize(),
-            cameraPositionState = cameraPositionState
+            cameraPositionState = cameraPositionState,
+            onMapClick = { latLng ->
+                viewModel.selectLatLon = latLng
+            }
         ) {
             MapEffect { map ->
                 //パーミッションチェック
@@ -63,11 +75,33 @@ fun LocationSelectScreen(
                     map.isMyLocationEnabled = true
                 }
             }
+
+            Marker(
+                state = MarkerState(viewModel.selectLatLon),
+                title = "hogehoge",
+            )
+        }
+
+        Card(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 62.dp)
+        ){
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+            ) {
+                Text(text = "緯度: ${String.format(Locale.JAPAN, "%.6f", viewModel.selectLatLon.latitude)}")
+                Text(text = "経度: ${String.format(Locale.JAPAN, "%.6f", viewModel.selectLatLon.longitude)}")
+            }
         }
 
         Button(
             onClick = {
+                viewModel.selectLatLon = LatLng(0.0,0.0)
+                toBackEditor(viewModel.selectLatLon)
             },
+            enabled = viewModel.selectLatLon != LatLng(0.0,0.0),
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 32.dp)

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelect.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -48,6 +49,13 @@ fun LocationSelectScreen(
         position = CameraPosition.fromLatLngZoom(defaultPosition, defaultZoom)
     }
 
+    // 選択された位置を保持するステート
+    var selectedLocation by remember { mutableStateOf(LatLng(0.0,0.0)) }
+    val markerState = remember { MarkerState(selectedLocation) }
+    LaunchedEffect(selectedLocation) {
+        markerState.position = selectedLocation
+    }
+
     viewModel.changeLocation(
         cameraPositionState = cameraPositionState
     )
@@ -58,7 +66,7 @@ fun LocationSelectScreen(
             modifier = Modifier.fillMaxSize(),
             cameraPositionState = cameraPositionState,
             onMapClick = { latLng ->
-                viewModel.selectLatLon = latLng
+                selectedLocation = latLng
             }
         ) {
             MapEffect { map ->
@@ -77,19 +85,19 @@ fun LocationSelectScreen(
             }
 
             Marker(
-                state = MarkerState(viewModel.selectLatLon),
+                state = markerState,
                 title =
                     "緯度: ${
                         String.format(
                             Locale.JAPAN,
                             "%.6f",
-                            viewModel.selectLatLon.latitude
+                            selectedLocation.latitude
                         )
                     }　経度: ${
                         String.format(
                             Locale.JAPAN,
                             "%.6f",
-                            viewModel.selectLatLon.longitude
+                            selectedLocation.longitude
                         )
                     }"
             )
@@ -104,17 +112,17 @@ fun LocationSelectScreen(
                 modifier = Modifier
                     .padding(16.dp)
             ) {
-                Text(text = "緯度: ${String.format(Locale.JAPAN, "%.6f", viewModel.selectLatLon.latitude)}")
-                Text(text = "経度: ${String.format(Locale.JAPAN, "%.6f", viewModel.selectLatLon.longitude)}")
+                Text(text = "緯度: ${String.format(Locale.JAPAN, "%.6f", selectedLocation.latitude)}")
+                Text(text = "経度: ${String.format(Locale.JAPAN, "%.6f", selectedLocation.longitude)}")
             }
         }
 
         Button(
             onClick = {
-                viewModel.selectLatLon = LatLng(0.0,0.0)
-                toBackEditor(viewModel.selectLatLon)
+                selectedLocation = LatLng(0.0,0.0)
+                toBackEditor(selectedLocation)
             },
-            enabled = viewModel.selectLatLon != LatLng(0.0,0.0),
+            enabled = selectedLocation != LatLng(0.0,0.0),
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 32.dp)

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelectViewModel.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelectViewModel.kt
@@ -15,9 +15,6 @@ import net.harutiro.trainalert2.features.map.repository.MapRepository
 
 class LocationSelectViewModel: ViewModel() {
 
-    var selectLatLon by mutableStateOf(LatLng(0.0, 0.0))
-
-
     private val mapRepository = MapRepository()
 
     fun init(context: Context) {

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelectViewModel.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelectViewModel.kt
@@ -2,6 +2,10 @@ package net.harutiro.trainalert2.core.presenter.LocationSelect
 
 import android.content.Context
 import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -10,6 +14,9 @@ import net.harutiro.trainalert2.features.map.entity.LocationData
 import net.harutiro.trainalert2.features.map.repository.MapRepository
 
 class LocationSelectViewModel: ViewModel() {
+
+    var selectLatLon by mutableStateOf(LatLng(0.0, 0.0))
+
 
     private val mapRepository = MapRepository()
 

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelectViewModel.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/LocationSelect/LocationSelectViewModel.kt
@@ -1,0 +1,41 @@
+package net.harutiro.trainalert2.core.presenter.LocationSelect
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.CameraPositionState
+import net.harutiro.trainalert2.features.map.entity.LocationData
+import net.harutiro.trainalert2.features.map.repository.MapRepository
+
+class LocationSelectViewModel: ViewModel() {
+
+    private val mapRepository = MapRepository()
+
+    fun init(context: Context) {
+        mapRepository.initMapApi(context)
+    }
+
+    fun changeLocation(cameraPositionState: CameraPositionState) {
+        mapRepository.getMapLocationData { locationData ->
+            mapCameraPosition(
+                cameraPosition = LocationData(
+                    latitude = locationData.latitude,
+                    longitude = locationData.longitude
+                ),
+                cameraPositionState = cameraPositionState
+            )
+        }
+    }
+
+    private fun mapCameraPosition(
+        cameraPosition: LocationData,
+        cameraPositionState: CameraPositionState
+    ) {
+        //カメラ初期値
+        val defaultPosition = LatLng(cameraPosition.latitude, cameraPosition.longitude)
+        val defaultZoom = 14f
+        cameraPositionState.position = CameraPosition.fromLatLngZoom(defaultPosition, defaultZoom)
+    }
+}

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
@@ -1,9 +1,9 @@
 package net.harutiro.trainalert2.core.presenter.routeEditer
 
+import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,10 +14,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
@@ -36,18 +34,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.Popup
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.android.gms.maps.model.LatLng
 import net.harutiro.trainalert2.core.presenter.LocationSelect.LocationSelectScreen
 import net.harutiro.trainalert2.core.presenter.home.HomeViewModel
-import android.content.Context
-import net.harutiro.trainalert2.features.room.routeDB.entities.RouteEntity
-import net.harutiro.trainalert2.features.map.entity.LocationData
 import java.util.Locale
 
 

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
@@ -1,30 +1,48 @@
 package net.harutiro.trainalert2.core.presenter.routeEditer
 
-import net.harutiro.trainalert2.core.presenter.routeEditer.RouteEditorViewModel
+import android.content.Context
 import android.util.Log
 import android.widget.Toast
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.Popup
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.android.gms.maps.model.LatLng
+import net.harutiro.trainalert2.core.presenter.LocationSelect.LocationSelectScreen
 import net.harutiro.trainalert2.core.presenter.home.HomeViewModel
-import android.content.Context
+import net.harutiro.trainalert2.features.map.entity.LocationData
+import java.util.Locale
 
 
 @Composable
@@ -32,6 +50,10 @@ fun RouteEditScreen(
     toBackScreen: () -> Unit,
     homeViewModel: HomeViewModel = viewModel()
 ) {
+    var isDialogVisible by remember { mutableStateOf(false) }
+    var selectedTitle by remember { mutableStateOf("") }
+    var onLocationSelected: ((LatLng) -> Unit)? by remember { mutableStateOf(null) }
+
     val viewModel: RouteEditorViewModel = viewModel(factory = RouteEditorViewModelFactory(homeViewModel))
     val context = LocalContext.current
 
@@ -56,49 +78,37 @@ fun RouteEditScreen(
         )
         Spacer(modifier = Modifier.height(16.dp))
 
-        // 出発地点の経度入力フィールド
-        TextField(
-            value = viewModel.startLongitude,
-            onValueChange = { viewModel.startLongitude = it },
-            label = { Text("出発地点の経度") },
-            placeholder = { Text("例: 123.456") },
-            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
+        // 出発地点
+        LocationSelectionCard(
+            title = "出発地点の経度・緯度",
+            latitude = viewModel.startLatitude,
+            longitude = viewModel.startLongitude,
+            onClick = {
+                selectedTitle = "出発地点の経度・緯度を選択"
+                onLocationSelected = { location ->
+                    viewModel.startLongitude = location.longitude.toString()
+                    viewModel.startLatitude = location.latitude.toString()
+                }
+                isDialogVisible = true
+            }
         )
+
         Spacer(modifier = Modifier.height(16.dp))
 
-        // 出発地点の緯度入力フィールド
-        TextField(
-            value = viewModel.startLatitude,
-            onValueChange = { viewModel.startLatitude = it },
-            label = { Text("出発地点の緯度") },
-            placeholder = { Text("例: 34.567") },
-            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
+        // 到着地点
+        LocationSelectionCard(
+            title = "到着地点の経度・緯度",
+            latitude = viewModel.endLatitude,
+            longitude = viewModel.endLongitude,
+            onClick = {
+                selectedTitle = "到着地点の経度・緯度を選択"
+                onLocationSelected = { location ->
+                    viewModel.endLongitude = location.longitude.toString()
+                    viewModel.endLatitude = location.latitude.toString()
+                }
+                isDialogVisible = true
+            }
         )
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // 到着地点の経度入力フィールド
-        TextField(
-            value = viewModel.endLongitude,
-            onValueChange = { viewModel.endLongitude = it },
-            label = { Text("到着地点の経度") },
-            placeholder = { Text("例: 123.456") },
-            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // 到着地点の緯度入力フィールド
-        TextField(
-            value = viewModel.endLatitude,
-            onValueChange = { viewModel.endLatitude = it },
-            label = { Text("到着地点の緯度") },
-            placeholder = { Text("例: 34.567") },
-            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(modifier = Modifier.height(24.dp)) // 余白を少し大きめに
 
 
         // アラート方法（通知、バイブレーション）の選択
@@ -167,7 +177,112 @@ fun RouteEditScreen(
             }
         }
     }
+
+    // ポップアップの表示
+    if (isDialogVisible) {
+        ShowLocationSelectDialog(
+            title = selectedTitle,
+            onDismissRequest = { isDialogVisible = false },
+            onLocationSelected = { location ->
+                onLocationSelected?.invoke(location)
+                isDialogVisible = false // ダイアログを閉じる
+            }
+        )
+    }
 }
+
+// 位置情報選択用のカードコンポーネント
+@Composable
+fun LocationSelectionCard(
+    title: String,
+    latitude: String,
+    longitude: String,
+    onClick: () -> Unit
+) {
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = title,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column {
+                    var convertLatitude = ""
+                    var convertLongitude = ""
+                    if(latitude.isNotEmpty()){
+                        convertLongitude = String.format(
+                            Locale.JAPAN,
+                            "%.6f",
+                            longitude.toDouble()
+                        )
+                    }
+                    if(longitude.isNotEmpty()){
+                        convertLatitude = String.format(
+                            Locale.JAPAN,
+                            "%.6f",
+                            latitude.toDouble()
+                        )
+                    }
+                    Text(text = "経度：${convertLongitude}", fontSize = 14.sp)
+                    Text(text = "緯度：${convertLatitude}", fontSize = 14.sp)
+                }
+                Button(
+                    onClick = onClick,
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier.padding(8.dp)
+                ) {
+                    Text("位置を選択")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ShowLocationSelectDialog(
+    title: String,
+    onDismissRequest:()->Unit ,
+    onLocationSelected: (LatLng) -> Unit
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .fillMaxHeight(0.7f)
+        ) {
+            Column{
+                Text(
+                    text="経度・緯度を選択",
+                    fontSize = 24.sp,
+                    modifier = Modifier
+                        .padding(8.dp),
+                )
+                LocationSelectScreen(
+                    toBackEditor = { location ->
+                        onLocationSelected(location)
+                    }
+                )
+            }
+        }
+    }
+}
+
 // トーストを表示するための関数
 fun showToast(context: Context, message: String?) {
     message?.let {

--- a/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/presenter/routeEditer/RouteEditorScreen.kt
@@ -16,9 +16,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -84,7 +89,7 @@ fun RouteEditScreen(
             latitude = viewModel.startLatitude,
             longitude = viewModel.startLongitude,
             onClick = {
-                selectedTitle = "出発地点の経度・緯度を選択"
+                selectedTitle = "出発地点をタップしてください"
                 onLocationSelected = { location ->
                     viewModel.startLongitude = location.longitude.toString()
                     viewModel.startLatitude = location.latitude.toString()
@@ -101,7 +106,7 @@ fun RouteEditScreen(
             latitude = viewModel.endLatitude,
             longitude = viewModel.endLongitude,
             onClick = {
-                selectedTitle = "到着地点の経度・緯度を選択"
+                selectedTitle = "到着地点をタップしてください"
                 onLocationSelected = { location ->
                     viewModel.endLongitude = location.longitude.toString()
                     viewModel.endLatitude = location.latitude.toString()
@@ -267,12 +272,24 @@ fun ShowLocationSelectDialog(
                 .fillMaxHeight(0.7f)
         ) {
             Column{
-                Text(
-                    text="経度・緯度を選択",
-                    fontSize = 24.sp,
-                    modifier = Modifier
-                        .padding(8.dp),
-                )
+                Row{
+                    IconButton(
+                        onClick = {
+                            onDismissRequest()
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                    Text(
+                        text=title,
+                        fontSize = 24.sp,
+                        modifier = Modifier
+                            .padding(8.dp),
+                    )
+                }
                 LocationSelectScreen(
                     toBackEditor = { location ->
                         onLocationSelected(location)

--- a/app/src/main/java/net/harutiro/trainalert2/core/router/MainRouter.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/router/MainRouter.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import net.harutiro.trainalert2.core.presenter.LocationSelect.LocationSelectScreen
 import net.harutiro.trainalert2.core.presenter.map.MapScreen
 import net.harutiro.trainalert2.core.presenter.home.HomeScreen
 import net.harutiro.trainalert2.core.presenter.routeEditer.RouteEditScreen
@@ -31,7 +30,7 @@ fun MainRouter(
             changeTopBarTitle(BottomNavigationBarRoute.HOME.title)
         }
         composable(BottomNavigationBarRoute.MAP.route) {
-            LocationSelectScreen()
+            MapScreen()
             changeTopBarTitle(BottomNavigationBarRoute.MAP.title)
         }
         composable(BottomNavigationBarRoute.ROUTE_EDITOR.route) {

--- a/app/src/main/java/net/harutiro/trainalert2/core/router/MainRouter.kt
+++ b/app/src/main/java/net/harutiro/trainalert2/core/router/MainRouter.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import net.harutiro.trainalert2.core.presenter.LocationSelect.LocationSelectScreen
 import net.harutiro.trainalert2.core.presenter.map.MapScreen
 import net.harutiro.trainalert2.core.presenter.home.HomeScreen
 import net.harutiro.trainalert2.core.presenter.routeEditer.RouteEditScreen
@@ -30,7 +31,7 @@ fun MainRouter(
             changeTopBarTitle(BottomNavigationBarRoute.HOME.title)
         }
         composable(BottomNavigationBarRoute.MAP.route) {
-            MapScreen()
+            LocationSelectScreen()
             changeTopBarTitle(BottomNavigationBarRoute.MAP.title)
         }
         composable(BottomNavigationBarRoute.ROUTE_EDITOR.route) {


### PR DESCRIPTION
# 概要

マップの編集画面で、ポップアップを利用して、マップを表示して、
Mapにピンを刺して、位置情報を選択できるようにしました。

# 動作でも

https://github.com/user-attachments/assets/a55f882f-55b9-4fb6-9458-a2ea6b6148b5

